### PR TITLE
Add ability to save the pdf to wp-content/uploads

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: dkjensen, seattlewebco
 Tested up to: 5.2.4
 Requires PHP: 5.6.0
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 
 Adds ability for users and guests to download their WooCommerce cart as PDF
 
@@ -14,6 +14,10 @@ Useful for many cases such as if a user needs a quote before completing purchase
 == Installation ==
 1. Upload plugin and then activate
 2. Ensure WooCommerce is installed and activated as well
+
+== Changelog ==
+2.0.3
+* Add custom action before output to send an email or create a custom post
 
 == Changelog ==
 2.0.2

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: dkjensen, seattlewebco
 Tested up to: 5.2.4
 Requires PHP: 5.6.0
-Stable tag: 2.0.1
+Stable tag: 2.0.2
 
 Adds ability for users and guests to download their WooCommerce cart as PDF
 
@@ -14,6 +14,10 @@ Useful for many cases such as if a user needs a quote before completing purchase
 == Installation ==
 1. Upload plugin and then activate
 2. Ensure WooCommerce is installed and activated as well
+
+== Changelog ==
+2.0.2
+* Add ability to save the pdf to wp-content/uploads/wc-cart-pdf folder with new 'wc_cart_pdf_save' filter (defaults to false)
 
 == Changelog ==
 2.0.1
@@ -99,7 +103,7 @@ Add the following code snippet to your themes functions.php:
 
         <p><a href="<?php echo get_permalink( get_option( 'woocommerce_myaccount_page_id' ) ); ?>" class="cart-pdf-login"><?php esc_html_e( 'Please login to download your cart as a PDF', 'wc-cart-pdf' ); ?></a></p>
 
-        <?php 
+        <?php
         endif;
     }
     add_action( 'woocommerce_proceed_to_checkout', 'child_theme_wc_cart_pdf_button', 21 );

--- a/wc-cart-pdf.php
+++ b/wc-cart-pdf.php
@@ -103,10 +103,13 @@ function wc_cart_pdf_process_download() {
     $mpdf->WriteHTML( $css, \Mpdf\HTMLParserMode::HEADER_CSS );
     $mpdf->WriteHTML( $content, \Mpdf\HTMLParserMode::HTML_BODY );
 
+    // Create filename before output actions, to avoid different file names between download and saved pdf
+    $filename = apply_filters( 'wc_cart_pdf_filename', 'WC_Cart-' . date( 'Ymd' ) . bin2hex( openssl_random_pseudo_bytes( 5 ) ) ) . '.pdf';
+
     // Add a new filter 'wc_cart_pdf_save' option and save the pdf to wp-content/woocommerce-cart-pdf/ folder
     if (apply_filters('wc_cart_pdf_save', false) == true) {
         $mpdf->Output(
-            $uploads_folder . apply_filters( 'wc_cart_pdf_filename', 'WC_Cart-' . date( 'Ymd' ) . bin2hex( openssl_random_pseudo_bytes( 5 ) ) ) . '.pdf',
+            $uploads_folder . $filename,
             \Mpdf\Output\Destination::FILE
         );
     }
@@ -114,7 +117,7 @@ function wc_cart_pdf_process_download() {
     // Continue standard download behaviour
     $dest = \Mpdf\Output\Destination::DOWNLOAD;
     $mpdf->Output(
-        apply_filters( 'wc_cart_pdf_filename', 'WC_Cart-' . date( 'Ymd' ) . bin2hex( openssl_random_pseudo_bytes( 5 ) ) ) . '.pdf',
+        $filename,
         apply_filters( 'wc_cart_pdf_destination', $dest )
     );
 

--- a/wc-cart-pdf.php
+++ b/wc-cart-pdf.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:     WooCommerce Cart PDF
  * Description:     Allows customers to download their cart as a PDF
- * Version:         2.0.2
+ * Version:         2.0.3
  * Author:          Seattle Web Co.
  * Author URI:      https://seattlewebco.com
  * Text Domain:     wc-cart-pdf

--- a/wc-cart-pdf.php
+++ b/wc-cart-pdf.php
@@ -206,6 +206,26 @@ function wc_cart_pdf_customize_register( $wp_customize ) {
 add_action( 'customize_register', 'wc_cart_pdf_customize_register' );
 
 
+
+/**
+ * Plugin activation hook
+ *
+ * @since 2.0.2
+ * @return void
+ */
+function wc_cart_pdf_activate() {
+    $upload = wp_upload_dir();
+    $upload_dir = $upload['basedir'];
+    $upload_dir = $upload_dir . '/wc-cart-pdf';
+    if (! is_dir($upload_dir)) {
+       mkdir( $upload_dir, 0755 );
+    }
+}
+
+register_activation_hook( __FILE__, 'wc_cart_pdf_activate' );
+
+
+
 /**
  * Expand {site_title} placeholder variable
  *

--- a/wc-cart-pdf.php
+++ b/wc-cart-pdf.php
@@ -114,6 +114,11 @@ function wc_cart_pdf_process_download() {
         );
     }
 
+
+    // Run some custom code, for mailing the pdf or create a post
+    do_action( 'wc_cart_pdf_after_action', $uploads_folder, $filename);
+
+
     // Continue standard download behaviour
     $dest = \Mpdf\Output\Destination::DOWNLOAD;
     $mpdf->Output(

--- a/wc-cart-pdf.php
+++ b/wc-cart-pdf.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:     WooCommerce Cart PDF
  * Description:     Allows customers to download their cart as a PDF
- * Version:         2.0.1
+ * Version:         2.0.2
  * Author:          Seattle Web Co.
  * Author URI:      https://seattlewebco.com
  * Text Domain:     wc-cart-pdf
@@ -76,7 +76,7 @@ function wc_cart_pdf_process_download() {
 
         $content = ob_get_clean();
     }
-    
+
     if( file_exists( $css ) ) {
         ob_start();
 
@@ -132,7 +132,7 @@ function wc_cart_pdf_button() {
     if( ! is_cart() || WC()->cart->is_empty() ) {
         return;
     }
-    
+
     ?>
 
     <a href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'cart-pdf' => '1' ), wc_get_cart_url() ), 'cart-pdf' ) );?>" class="cart-pdf-button button" target="_blank">

--- a/wc-cart-pdf.php
+++ b/wc-cart-pdf.php
@@ -87,6 +87,9 @@ function wc_cart_pdf_process_download() {
 
     $dest = \Mpdf\Output\Destination::DOWNLOAD;
 
+    $uploads_dir = wp_upload_dir( $time = null, $create_dir = true, $refresh_cache = false );
+    $uploads_folder = $uploads_dir['basedir'] . '/wc-cart-pdf/';
+
     if ( is_rtl() ) {
         $mpdf->SetDirectionality( 'rtl' );
     }
@@ -99,8 +102,19 @@ function wc_cart_pdf_process_download() {
 
     $mpdf->WriteHTML( $css, \Mpdf\HTMLParserMode::HEADER_CSS );
     $mpdf->WriteHTML( $content, \Mpdf\HTMLParserMode::HTML_BODY );
-    $mpdf->Output( 
-        apply_filters( 'wc_cart_pdf_filename', 'WC_Cart-' . date( 'Ymd' ) . bin2hex( openssl_random_pseudo_bytes( 5 ) ) ) . '.pdf', 
+
+    // Add a new filter 'wc_cart_pdf_save' option and save the pdf to wp-content/woocommerce-cart-pdf/ folder
+    if (apply_filters('wc_cart_pdf_save', false) == true) {
+        $mpdf->Output(
+            $uploads_folder . apply_filters( 'wc_cart_pdf_filename', 'WC_Cart-' . date( 'Ymd' ) . bin2hex( openssl_random_pseudo_bytes( 5 ) ) ) . '.pdf',
+            \Mpdf\Output\Destination::FILE
+        );
+    }
+
+    // Continue standard download behaviour
+    $dest = \Mpdf\Output\Destination::DOWNLOAD;
+    $mpdf->Output(
+        apply_filters( 'wc_cart_pdf_filename', 'WC_Cart-' . date( 'Ymd' ) . bin2hex( openssl_random_pseudo_bytes( 5 ) ) ) . '.pdf',
         apply_filters( 'wc_cart_pdf_destination', $dest )
     );
 


### PR DESCRIPTION
For a client project I needed the cart pdf to be saved as an offer. So the client needs to have the pdf with the cart contents. 

So I added some small functionality that saves the pdf to the wp-content/uploads/wc-cart-pdf folder.

This can be enabled with a new filter: 'wc_cart_pdf_save', which defaults to false, but can ben set to true to have it saved on disk.

Please let me know what you think of this.

Gr, Jurgen